### PR TITLE
表示される歯ブラシ名を文字数制限し、ホバーすることで全文表示される処理を追加

### DIFF
--- a/app/views/toothbrushes/_toothbrush.html.erb
+++ b/app/views/toothbrushes/_toothbrush.html.erb
@@ -5,8 +5,8 @@
         <%= image_tag toothbrush.item_image_urls, size: '128x128' if toothbrush.item_image_urls.present? %>
       </div>
       <div class="card-body" id="index-card">
-        <p class="card-title text-center">
-          <%= toothbrush.item_name %>
+        <p class="card-title text-center" title="<%= toothbrush.item_name %>">
+          <%= truncate(toothbrush.item_name, length: 25) %>
         </p>
         <ul class="list-group">
           <li class="list-group-item text-center">

--- a/app/views/users/_user_toothbrushes.html.erb
+++ b/app/views/users/_user_toothbrushes.html.erb
@@ -15,8 +15,8 @@
       <td>
         <%= image_tag toothbrush.item_image_urls, size: '128x128' if toothbrush.item_image_urls.present? %>
       </td>
-      <td>
-        <%= toothbrush.item_name %>
+      <td title="<%= toothbrush.item_name %>">
+        <%= truncate(toothbrush.item_name, length: 30) %>
       </td>
       <td>
         <%= toothbrush.brush_material_i18n %>


### PR DESCRIPTION
ユーザー詳細画面と歯ブラシ一覧画面で表示される歯ブラシ名の文字数を制限し、見やすくしました。
また、歯ブラシ名にカーソルをホバーすることで全文が表示されるようにもしました。

<img width="1333" alt="user_show_hover" src="https://github.com/TAMETOMO8/Haburashi_Life/assets/117285256/9fa4148a-90d8-4dd5-a4e7-11bc26f763e5">


<img width="1427" alt="toothbrush_index_hover" src="https://github.com/TAMETOMO8/Haburashi_Life/assets/117285256/f3cbecf4-35f6-46d5-8b6c-e72be9159926">


ただし、ホバーしてから全文表示されるまでタイムラグがあるので、解消できるかどうか調査を行う必要はあります。